### PR TITLE
feat(lib:design-system): Add directive for text hyperlinks (#946)

### DIFF
--- a/libs/design-system/buttons/src/lib/buttons.module.ts
+++ b/libs/design-system/buttons/src/lib/buttons.module.ts
@@ -1,21 +1,23 @@
 import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import {
-  CtaButtonDirective,
   ButtonSizeDirective,
   ButtonVariantDirective,
+  CtaButtonDirective,
   PrimaryButtonVariantDirective,
   SecondaryButtonVariantDirective,
 } from '@hra-ui/design-system/buttons/button';
+import { TextHyperlinkDirective } from '@hra-ui/design-system/buttons/text-hyperlink';
 
 /** All re-exported modules, components, directives, etc. */
 const REEXPORTS = [
   MatButtonModule,
-  CtaButtonDirective,
   ButtonSizeDirective,
   ButtonVariantDirective,
+  CtaButtonDirective,
   PrimaryButtonVariantDirective,
   SecondaryButtonVariantDirective,
+  TextHyperlinkDirective,
 ];
 
 /** Packages up subpackage angular exports for easier use */

--- a/libs/design-system/buttons/text-hyperlink/src/index.ts
+++ b/libs/design-system/buttons/text-hyperlink/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/providers';
+export * from './lib/text-hyperlink.directive';

--- a/libs/design-system/buttons/text-hyperlink/src/lib/global-styles.component.scss
+++ b/libs/design-system/buttons/text-hyperlink/src/lib/global-styles.component.scss
@@ -1,7 +1,11 @@
 @use '../../../../styles/utils';
 
 @include utils.global-styles() {
-  a:not(.mdc-button) {
+  a:not(.hra-text-hyperlink) {
+    text-decoration: none;
+  }
+
+  a.hra-text-hyperlink {
     &:link {
       color: var(--sys-on-tertiary-fixed);
       text-decoration: none;

--- a/libs/design-system/buttons/text-hyperlink/src/lib/text-hyperlink.directive.ts
+++ b/libs/design-system/buttons/text-hyperlink/src/lib/text-hyperlink.directive.ts
@@ -1,0 +1,11 @@
+import { Directive } from '@angular/core';
+
+/** Applies hyperlink styles when placed on an <a> tag */
+@Directive({
+  selector: 'a[hraHyperlink]',
+  standalone: true,
+  host: {
+    class: 'hra-text-hyperlink',
+  },
+})
+export class TextHyperlinkDirective {}

--- a/libs/design-system/buttons/text-hyperlink/src/lib/text-hyperlink.stories.ts
+++ b/libs/design-system/buttons/text-hyperlink/src/lib/text-hyperlink.stories.ts
@@ -1,4 +1,5 @@
-import { Meta, StoryObj } from '@storybook/angular';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { TextHyperlinkDirective } from './text-hyperlink.directive';
 
 const meta: Meta<{ link: string }> = {
   title: 'Design System/Buttons/TextHyperlink',
@@ -13,8 +14,13 @@ const meta: Meta<{ link: string }> = {
   },
   render: (args) => ({
     props: args,
-    template: `<a href="${args.link}" target="_blank" rel="noopener noreferrer">${args.link}</a>`,
+    template: `<a hraHyperlink href="${args.link}" target="_blank" rel="noopener noreferrer">${args.link}</a>`,
   }),
+  decorators: [
+    moduleMetadata({
+      imports: [TextHyperlinkDirective],
+    }),
+  ],
 };
 export default meta;
 type Story = StoryObj;


### PR DESCRIPTION
* feat(lib:design-system): Add directive for text hyperlinks

Styles are now only applied if the <a> tag has the hyperlink directive. This will prevent the styles from interfering with other elements

* docs(lib:design-system): :memo: Add docs for hyperlink directive