### PR TITLE
Us1 improvements

### DIFF
--- a/apps/apps.humanatlas.io/src/app/app.component.scss
+++ b/apps/apps.humanatlas.io/src/app/app.component.scss
@@ -11,11 +11,3 @@
     flex-direction: column;
   }
 }
-
-@media only screen and (max-width: 944px) {
-  .content {
-    width: 100%;
-    margin: 0;
-    padding: 0;
-  }
-}

--- a/apps/apps.humanatlas.io/src/app/app.component.scss
+++ b/apps/apps.humanatlas.io/src/app/app.component.scss
@@ -11,3 +11,11 @@
     flex-direction: column;
   }
 }
+
+@media only screen and (max-width: 944px) {
+  .content {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+  }
+}

--- a/apps/apps.humanatlas.io/src/app/components/product-header/product-header.component.scss
+++ b/apps/apps.humanatlas.io/src/app/components/product-header/product-header.component.scss
@@ -9,6 +9,7 @@
   }
 
   .title {
+    padding-left: 1.25rem;
     min-width: 18.75rem;
     display: flex;
     flex-direction: column;
@@ -30,10 +31,12 @@
     font: var(--mat-sys-label-large);
     letter-spacing: var(--mat-sys-label-large-tracking);
   }
+}
 
-  @media only screen and (min-width: 640px) {
+@media only screen and (max-width: 560px) {
+  :host {
     .title {
-      padding-left: 1.25rem;
+      padding-left: 0;
     }
   }
 }

--- a/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictions/cell-population-predictions.component.html
+++ b/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictions/cell-population-predictions.component.html
@@ -38,40 +38,42 @@
   </hra-workflow-card-extra>
 
   <!-- TABLE -->
-  <table mat-table [dataSource]="dataSource" matSort class="predictions-table">
-    <caption>
-      Table displaying cell population predictions.
-    </caption>
-    <ng-container matColumnDef="tool">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by Tool">Tool</th>
-      <td mat-cell *matCellDef="let element">{{ element.tool }}</td>
-    </ng-container>
-    <ng-container matColumnDef="modality">
-      <th mat-header-cell *matHeaderCellDef>Modality</th>
-      <td mat-cell *matCellDef="let element">{{ element.modality }}</td>
-    </ng-container>
-    <ng-container matColumnDef="percentage">
-      <th mat-header-cell *matHeaderCellDef>% Of Total</th>
-      <td mat-cell *matCellDef="let element">
-        {{ element.percentage < 0.0001 ? '< 0.01%' : (element.percentage | percent: '1.2-2') }}
-      </td>
-    </ng-container>
-    <ng-container matColumnDef="count">
-      <th mat-header-cell *matHeaderCellDef># Count</th>
-      <td mat-cell *matCellDef="let element">{{ element.count | number: '1.2-2' }}</td>
-    </ng-container>
-    <ng-container matColumnDef="cell_label">
-      <th mat-header-cell *matHeaderCellDef>Cell Name in Cell Ontology (CL)</th>
-      <td mat-cell *matCellDef="let element">{{ element.cell_label }}</td>
-    </ng-container>
-    <ng-container matColumnDef="cell_id">
-      <th mat-header-cell *matHeaderCellDef>Cell Type ID in Cell Ontology (CL)</th>
-      <td mat-cell *matCellDef="let element">
-        <a [href]="element.cell_id">{{ element.cell_id }}</a>
-      </td>
-    </ng-container>
+  <ng-scrollbar class="table-overflow-container">
+    <table mat-table [dataSource]="dataSource" matSort class="predictions-table">
+      <caption>
+        Table displaying cell population predictions.
+      </caption>
+      <ng-container matColumnDef="tool">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by Tool">Tool</th>
+        <td mat-cell *matCellDef="let element">{{ element.tool }}</td>
+      </ng-container>
+      <ng-container matColumnDef="modality">
+        <th mat-header-cell *matHeaderCellDef>Modality</th>
+        <td mat-cell *matCellDef="let element">{{ element.modality }}</td>
+      </ng-container>
+      <ng-container matColumnDef="percentage">
+        <th mat-header-cell *matHeaderCellDef>% Of Total</th>
+        <td mat-cell *matCellDef="let element">
+          {{ element.percentage < 0.0001 ? '< 0.01%' : (element.percentage | percent: '1.2-2') }}
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="count">
+        <th mat-header-cell *matHeaderCellDef># Count</th>
+        <td mat-cell *matCellDef="let element">{{ element.count | number: '1.2-2' }}</td>
+      </ng-container>
+      <ng-container matColumnDef="cell_label">
+        <th mat-header-cell *matHeaderCellDef>Cell Name in Cell Ontology (CL)</th>
+        <td mat-cell *matCellDef="let element">{{ element.cell_label }}</td>
+      </ng-container>
+      <ng-container matColumnDef="cell_id">
+        <th mat-header-cell *matHeaderCellDef>Cell Type ID in Cell Ontology (CL)</th>
+        <td mat-cell *matCellDef="let element">
+          <a [href]="element.cell_id">{{ element.cell_id }}</a>
+        </td>
+      </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-  </table>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </ng-scrollbar>
 </hra-workflow-card>

--- a/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictions/cell-population-predictions.component.scss
+++ b/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictions/cell-population-predictions.component.scss
@@ -9,6 +9,7 @@ h1 {
   font: var(--mat-sys-display-large);
   letter-spacing: var(--mat-sys-display-large-tracking);
   margin: 0;
+  word-wrap: break-word;
 }
 
 button {
@@ -21,13 +22,14 @@ button {
   font: var(--mat-sys-body-large);
   letter-spacing: var(--mat-sys-body-large-tracking);
   color: var(--mat-sys-on-secondary-container);
+  word-wrap: break-word;
 }
 
 .table-container {
+  width: 100%;
   margin-top: 3rem;
-  margin-bottom: 0.3125rem;
-  max-height: 26rem;
-  overflow-y: auto;
+  margin-bottom: 3rem; // TODO
+  overflow: hidden;
 
   caption {
     display: none;
@@ -37,26 +39,42 @@ button {
     display: flex;
   }
 
-  .predictions-table {
-    background-color: var(--mat-sys-secondary-container);
-    border-collapse: collapse;
+  .table-overflow-container {
+    max-width: calc(100vw - 4rem);
+    max-height: 26rem;
+    overflow: auto;
+    border: 1px solid var(--mat-sys-outline);
+    border-radius: 0.25rem;
 
-    th,
-    td {
-      font: var(--mat-sys-label-medium);
-      letter-spacing: var(--mat-sys-label-medium-tracking);
-      border: 0.0625rem solid var(--mat-sys-outline);
-    }
+    .predictions-table {
+      background-color: var(--mat-sys-secondary-container);
+      width: 100%;
+      min-width: 54.0625rem;
 
-    th {
-      color: var(--mat-sys-on-primary-container);
-      background-color: var(--mat-sys-surface-container);
-    }
-    td {
-      color: var(--mat-sys-inverse-surface);
+      tr:not(:last-child) {
+        border-bottom: 0.0625rem solid var(--mat-sys-outline);
+      }
 
-      &:last-child a {
-        color: var(--mat-sys-on-tertiary-container);
+      th,
+      td {
+        font: var(--mat-sys-label-medium);
+        letter-spacing: var(--mat-sys-label-medium-tracking);
+
+        &:not(:last-child) {
+          border-right: 0.0625rem solid var(--mat-sys-outline);
+        }
+      }
+
+      th {
+        color: var(--mat-sys-on-primary-container);
+        background-color: var(--mat-sys-surface-container);
+      }
+      td {
+        color: var(--mat-sys-inverse-surface);
+
+        &:last-child a {
+          color: var(--mat-sys-on-tertiary-container);
+        }
       }
     }
   }

--- a/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictions/cell-population-predictions.component.scss
+++ b/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictions/cell-population-predictions.component.scss
@@ -26,6 +26,8 @@ button {
 .table-container {
   margin-top: 3rem;
   margin-bottom: 0.3125rem;
+  max-height: 26rem;
+  overflow-y: auto;
 
   caption {
     display: none;

--- a/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictions/cell-population-predictions.component.scss
+++ b/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictions/cell-population-predictions.component.scss
@@ -1,8 +1,7 @@
 :host {
   display: block;
   max-width: 72.5rem;
-  margin: 0 auto;
-  padding-top: 7.5rem;
+  margin: 10rem auto;
 }
 
 h1 {

--- a/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictions/cell-population-predictions.component.ts
+++ b/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictions/cell-population-predictions.component.ts
@@ -11,6 +11,7 @@ import { WorkflowCardModule } from '@hra-ui/design-system/workflow-card';
 import { TooltipCardComponent, TooltipContent } from '@hra-ui/design-system/tooltip-card';
 import { CellSummaryRow } from '@hra-api/ng-client';
 import { TissuePredictionData } from '../../../services/hra-pop-predictions/hra-pop-predictions.service';
+import { ScrollingModule } from '@hra-ui/design-system/scrolling';
 
 /** Tooltip Content */
 const TOOLTIP_CONTENT = `Cell Population: Number of cells per cell type in a tissue block, anatomical structure, or extraction site. Cell
@@ -38,6 +39,7 @@ const EMPTY_DATA: TissuePredictionData = {
     MatMenuModule,
     OverlayModule,
     TooltipCardComponent,
+    ScrollingModule,
   ],
   templateUrl: './cell-population-predictions.component.html',
   styleUrl: './cell-population-predictions.component.scss',

--- a/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictor/cell-population-predictor.component.scss
+++ b/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictor/cell-population-predictor.component.scss
@@ -36,7 +36,6 @@
   }
 
   .card-with-file {
-    height: auto !important;
     width: 27rem !important;
     display: flex;
     flex-direction: column;
@@ -51,8 +50,6 @@
   }
 
   .card {
-    height: 15.8125rem;
-    height: auto !important;
     width: 27rem;
     font: var(--mat-sys-label-large);
     letter-spacing: var(--mat-sys-label-large-tracking);

--- a/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictor/cell-population-predictor.component.scss
+++ b/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictor/cell-population-predictor.component.scss
@@ -2,8 +2,8 @@
   display: block;
   width: 100%;
   max-width: 58.75rem;
-  margin: 0 auto;
-  padding: 10rem 1rem;
+  margin: 10rem auto;
+  padding: 0 1rem;
 }
 
 .info-text {

--- a/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictor/cell-population-predictor.component.scss
+++ b/apps/apps.humanatlas.io/src/app/pages/us1/cell-population-predictor/cell-population-predictor.component.scss
@@ -1,5 +1,6 @@
 :host {
   display: block;
+  width: 100%;
   max-width: 58.75rem;
   margin: 0 auto;
   padding: 10rem 1rem;
@@ -35,7 +36,7 @@
   }
 
   .card-with-file {
-    height: 20.3125rem !important;
+    height: auto !important;
     width: 27rem !important;
     display: flex;
     flex-direction: column;
@@ -51,6 +52,7 @@
 
   .card {
     height: 15.8125rem;
+    height: auto !important;
     width: 27rem;
     font: var(--mat-sys-label-large);
     letter-spacing: var(--mat-sys-label-large-tracking);

--- a/libs/design-system/workflow-card/src/lib/workflow-card.component.scss
+++ b/libs/design-system/workflow-card/src/lib/workflow-card.component.scss
@@ -1,6 +1,7 @@
 :host {
   display: block;
   position: relative;
+  height: auto;
   padding: 2rem;
   border-radius: 1rem;
   overflow: hidden;


### PR DESCRIPTION
Add scrolling to the table and set a max height to 26rem for predictions page.

Predictor page:
Made the gray background hug width completely and added responsiveness to cards.