### PR TITLE
Updated Grlc URL patterns

### DIFF
--- a/apps/apps.humanatlas.io/src/app/constants/server.constants.ts
+++ b/apps/apps.humanatlas.io/src/app/constants/server.constants.ts
@@ -19,6 +19,13 @@ export const servers: Server[] = [
     url: 'https://apps.humanatlas.io/api',
     spec: 'https://apps.humanatlas.io/api/hra-api-spec.yaml',
   },
+  /* HRA-API SPARQL Queries */
+  {
+    id: 'grlc',
+    description: 'HRA-API SPARQL Queries',
+    url: 'https://apps.humanatlas.io/api/grlc/',
+    spec: 'https://apps.humanatlas.io/api/grlc/index-spec.json',
+  },
   /* staging server */
   {
     id: 'staging',
@@ -30,14 +37,7 @@ export const servers: Server[] = [
   {
     id: 'ccf-api',
     description: 'CCF-API (deprecated) Production',
-    url: 'https://apps.humanatlas.io/hra-api/v1',
+    url: 'https://apps.humanatlas.io/hra-api/',
     spec: 'https://apps.humanatlas.io/hra-api/ccf-api-spec.yaml',
-  },
-  /* HRA-API SPARQL Queries */
-  {
-    id: 'sparql',
-    description: 'HRA-API SPARQL Queries',
-    url: 'https://grlc.io/api-git/hubmapconsortium/ccf-grlc/subdir',
-    spec: 'https://apps.humanatlas.io/api/grlc/index-spec.json',
   },
 ];

--- a/apps/docs.humanatlas.io/public/assets/content/api-reference-page/data.yaml
+++ b/apps/docs.humanatlas.io/public/assets/content/api-reference-page/data.yaml
@@ -364,12 +364,12 @@ content:
 
       - component: TextHyperlink
         text: HRA-KG queries (SPARQL via grlc)
-        url: https://grlc.io/api-git/hubmapconsortium/ccf-grlc/subdir/hra/
+        url: https://apps.humanatlas.io/api/grlc/hra.html
         icon: arrow_right_alt
 
       - component: TextHyperlink
         text: Ubergraph queries (SPARQL via grlc)
-        url: https://grlc.io/api-git/hubmapconsortium/ccf-grlc/subdir/ubergraph/
+        url: https://apps.humanatlas.io/api/grlc/ubergraph.html
         icon: arrow_right_alt
 
       - component: TextHyperlink

--- a/apps/docs.humanatlas.io/public/assets/content/knowledge-graph-page/data.yaml
+++ b/apps/docs.humanatlas.io/public/assets/content/knowledge-graph-page/data.yaml
@@ -69,7 +69,7 @@ content:
           To execute this query, use the following cURL command:
 
           ```bash
-          curl -L -g "https://grlc.io/api-git/hubmapconsortium/ccf-grlc/subdir/hra/as-3d-cnt"
+          curl -L -g "https://apps.humanatlas.io/api/grlc/hra/as-3d-cnt"
           ```
 
           The response will return the count of 3D anatomical structures in the graph, like this:

--- a/apps/ftu-ui-small-wc/src/assets/TEMP/ftu-data.mjs
+++ b/apps/ftu-ui-small-wc/src/assets/TEMP/ftu-data.mjs
@@ -2,10 +2,10 @@ import { readFileSync, writeFileSync } from 'fs';
 import Papa from 'papaparse';
 
 /** API Endpoint that fetches FTU dataset metadata */
-const FTU_DATASET_METADATA_API = 'http://grlc.io/api-git/hubmapconsortium/ccf-grlc/subdir/hra-scratch/ftu-datasets';
+const FTU_DATASET_METADATA_API = 'https://apps.humanatlas.io/api/grlc/hra-scratch/ftu-datasets';
 
 /** API Endpoint that computes a cell summary for each FTU as a whole */
-const FTU_CELL_SUMMARIES_API = 'http://grlc.io/api-git/hubmapconsortium/ccf-grlc/subdir/hra-scratch/ftu-cell-summaries';
+const FTU_CELL_SUMMARIES_API = 'https://apps.humanatlas.io/api/grlc/hra-scratch/ftu-cell-summaries';
 
 const CONTEXT = JSON.parse(readFileSync('context.jsonld').toString());
 

--- a/apps/ftu-ui/src/assets/TEMP/ftu-data.mjs
+++ b/apps/ftu-ui/src/assets/TEMP/ftu-data.mjs
@@ -2,10 +2,10 @@ import { readFileSync, writeFileSync } from 'fs';
 import Papa from 'papaparse';
 
 /** API Endpoint that fetches FTU dataset metadata */
-const FTU_DATASET_METADATA_API = 'http://grlc.io/api-git/hubmapconsortium/ccf-grlc/subdir/hra-scratch/ftu-datasets';
+const FTU_DATASET_METADATA_API = 'https://apps.humanatlas.io/api/grlc/hra-scratch/ftu-datasets';
 
 /** API Endpoint that computes a cell summary for each FTU as a whole */
-const FTU_CELL_SUMMARIES_API = 'http://grlc.io/api-git/hubmapconsortium/ccf-grlc/subdir/hra-scratch/ftu-cell-summaries';
+const FTU_CELL_SUMMARIES_API = 'https://apps.humanatlas.io/api/grlc/hra-scratch/ftu-cell-summaries';
 
 const CONTEXT = JSON.parse(readFileSync('context.jsonld').toString());
 

--- a/apps/humanatlas.io/src/assets/content/api-page/data.yaml
+++ b/apps/humanatlas.io/src/assets/content/api-page/data.yaml
@@ -28,8 +28,8 @@ content:
           - Production: https://lod.humanatlas.io
           - SPARQL Endpoint: https://lod.humanatlas.io/sparql
         - grlc APIs (SPARQL queries plus OpenAPI endpoints more info):
-          - grlc queries using the HRA-KG SPARQL endpoint: https://grlc.io/api-git/hubmapconsortium/ccf-grlc/subdir/hra/
-          - grlc queries using the Ubergraph SPARQL endpoint: https://grlc.io/api-git/hubmapconsortium/ccf-grlc/subdir/ubergraph/
+          - grlc queries using the HRA-KG SPARQL endpoint: https://apps.humanatlas.io/api/grlc/hra.html
+          - grlc queries using the Ubergraph SPARQL endpoint: https://apps.humanatlas.io/api/grlc/ubergraph.html
           - More queries available at: https://github.com/hubmapconsortium/ccf-grlc/
 
   - component: PageSection

--- a/apps/humanatlas.io/src/assets/content/release-notes-page/v2.0.yaml
+++ b/apps/humanatlas.io/src/assets/content/release-notes-page/v2.0.yaml
@@ -12,7 +12,7 @@ content:
       - component: Markdown
         data: |
           The Human Reference Atlas now includes 65 3D reference organs with 1,215 3D anatomical structures.
-          <a href="https://grlc.io/api-git/hubmapconsortium/ccf-grlc/subdir/ccf/#/default/get_as_3d_counts" target="_blank">This SPARQL query</a>
+          <a href="https://apps.humanatlas.io/api/grlc/ccf.html#get-/as-3d-counts" target="_blank">This SPARQL query</a>
           returns all anatomical structures with an Uberon ID, i.e., it retrieves the 1,215 anatomical structures plus the 65 organs for a total of 1,280 items.
 
       - component: Markdown


### PR DESCRIPTION
We have a new Grlc URL pattern at https://apps.humanatlas.io/api/grlc* which is replacing the old URL patterns. This PR updates existing URLs to point to new URLs.