### PR TITLE
Millitome webpage route fix

### DIFF
--- a/apps/humanatlas.io/src/assets/content/millitome/data.yaml
+++ b/apps/humanatlas.io/src/assets/content/millitome/data.yaml
@@ -58,7 +58,7 @@ content:
             label: Left/Right
         rows:
           - Organ: Kidney
-            organUrl: https://github.com/hubmapconsortium/hra-millitome/tree/main/millitomes/VH_F_Kidney_L/,
+            organUrl: https://github.com/hubmapconsortium/hra-millitome/tree/main/millitomes/VH_F_Kidney_L/
             Sex: Female
             LeftRight: Left
           - Organ: Kidney


### PR DESCRIPTION
Fix broken link in table for Kidney, female, left:
- Update `https://github.com/hubmapconsortium/hra-millitome/tree/main/millitomes/VH_F_Kidney_L/,` to `https://github.com/hubmapconsortium/hra-millitome/tree/main/millitomes/VH_F_Kidney_L/`
- Closes #1568 