### PR TITLE
🚑 fix circular dependency between release version and organ

### DIFF
--- a/libs/design-system/data-viewer/src/lib/data-viewer.component.html
+++ b/libs/design-system/data-viewer/src/lib/data-viewer.component.html
@@ -35,12 +35,12 @@
       <mat-select
         disableRipple
         panelClass="options-container"
-        [ngModel]="releaseVersion_()"
-        (ngModelChange)="releaseVersion.set($event.version)"
+        [ngModel]="releaseVersion()"
+        (ngModelChange)="releaseVersion.set($event)"
       >
         <mat-select-trigger>{{ releaseVersion_().label }}</mat-select-trigger>
         @for (dataset of releaseVersionData(); track dataset) {
-          <mat-option [value]="dataset">
+          <mat-option [value]="dataset.version">
             <div class="release-label">
               <span class="release-name">{{ dataset.label }}</span>
               <span class="release-date">{{ dataset.date }}</span>
@@ -56,12 +56,12 @@
       <mat-select
         disableRipple
         panelClass="options-container"
-        [(ngModel)]="organ_"
-        (ngModelChange)="organ.set($event.label)"
+        [ngModel]="organ()"
+        (ngModelChange)="organ.set($event)"
         class="organ-selector"
       >
         @for (organ of releaseVersion_().organData; track organ) {
-          <mat-option [value]="organ">{{ organ.label }}</mat-option>
+          <mat-option [value]="organ.label">{{ organ.label }}</mat-option>
         }
       </mat-select>
       @if (organ_() === undefined) {

--- a/libs/design-system/data-viewer/src/lib/data-viewer.component.ts
+++ b/libs/design-system/data-viewer/src/lib/data-viewer.component.ts
@@ -70,13 +70,25 @@ export class DataViewerComponent {
   /** constructor to set the release version and organ from the model from effect*/
   constructor() {
     effect(() => {
-      const releaseVersion = this.releaseVersion_();
-      this.releaseVersion.set(releaseVersion.version);
+      const data = this.releaseVersionData();
+      const currentReleaseVersion = this.releaseVersion();
+      const releaseVersion = data.find((item) => item.version === currentReleaseVersion) ?? data[0];
+
+      if (this.releaseVersion() !== releaseVersion.version) {
+        this.releaseVersion.set(releaseVersion.version);
+      }
     });
 
     effect(() => {
-      const organ = this.organ_();
-      this.organ.set(organ?.label ?? '');
+      const data = this.releaseVersionData();
+      const currentReleaseVersion = this.releaseVersion();
+      const releaseVersion = data.find((item) => item.version === currentReleaseVersion) ?? data[0];
+      const currentOrgan = this.organ() ?? releaseVersion.organData[0].label;
+      const organ = releaseVersion.organData.find((item) => item.label === currentOrgan);
+
+      if (this.organ() !== (organ?.label ?? '')) {
+        this.organ.set(organ?.label ?? '');
+      }
     });
   }
 }


### PR DESCRIPTION
This PR fixes #1610 and #1611

Cause: Circular dependency between release version and organ.
Fix: remove circular dependency and set models only when values actually change to prevent infinite loops
releaseVersion_ and organ_ only used for reading current state