### PR TITLE
FTU explorer empty space css fix

### DIFF
--- a/libs/ftu-ui-components/src/lib/organisms/src/lib/biomarker-table/biomarker-table.component.html
+++ b/libs/ftu-ui-components/src/lib/organisms/src/lib/biomarker-table/biomarker-table.component.html
@@ -1,5 +1,5 @@
 <!-- eslint-disable @angular-eslint/template/mouse-events-have-key-events -->
-<cdk-virtual-scroll-viewport tvsItemSize="28" headerHeight="97">
+<cdk-virtual-scroll-viewport [tvsItemSize]="rowHeight" [headerHeight]="headerHeight" [style.height.px]="viewportHeight">
   <table class="table" mat-table [dataSource]="dataSource" #table>
     <ng-container matColumnDef="type" sticky>
       <th mat-header-cell *matHeaderCellDef>Cell types</th>

--- a/libs/ftu-ui-components/src/lib/organisms/src/lib/biomarker-table/biomarker-table.component.scss
+++ b/libs/ftu-ui-components/src/lib/organisms/src/lib/biomarker-table/biomarker-table.component.scss
@@ -38,7 +38,6 @@
   );
 
   cdk-virtual-scroll-viewport {
-    display: block;
     width: 100%;
   }
 

--- a/libs/ftu-ui-components/src/lib/organisms/src/lib/biomarker-table/biomarker-table.component.scss
+++ b/libs/ftu-ui-components/src/lib/organisms/src/lib/biomarker-table/biomarker-table.component.scss
@@ -5,7 +5,6 @@
 :host {
   display: block;
   position: relative;
-  min-height: 14rem;
   width: 100%;
   table-layout: fixed;
 
@@ -39,7 +38,7 @@
   );
 
   cdk-virtual-scroll-viewport {
-    height: 100%;
+    display: block;
     width: 100%;
   }
 

--- a/libs/ftu-ui-components/src/lib/organisms/src/lib/biomarker-table/biomarker-table.component.ts
+++ b/libs/ftu-ui-components/src/lib/organisms/src/lib/biomarker-table/biomarker-table.component.ts
@@ -142,6 +142,23 @@ export class BiomarkerTableComponent<T extends DataCell> implements OnInit, OnCh
   /** Injects BottomSheetService */
   private readonly bottomSheetService = inject(BottomSheetService);
 
+  /** row height */
+  readonly rowHeight = 28;
+  /** header height */
+  readonly headerHeight = 97;
+  /** max visible rows */
+  readonly maxVisibleRows = 10;
+
+  /**
+   * Gets viewport height
+   * @returns viewport height in pixels
+   */
+  get viewportHeight(): number {
+    const rows = this.dataSource.data.length;
+    const visible = Math.min(rows, this.maxVisibleRows) + 1; // offset
+    return this.headerHeight + visible * this.rowHeight;
+  }
+
   /** Gets the current width of the prefiller column */
   get preFillerWidth(): string {
     return `${this.cellWidth * this.displayedColumnOffset}px`;


### PR DESCRIPTION
This PR fixes the empty space shown after the biomaker table.
closes https://github.com/hubmapconsortium/hra-ui/issues/1626


### Before

<img width="1494" height="666" alt="image" src="https://github.com/user-attachments/assets/4357d25b-f879-4890-942e-2627b22c6399" />


### After

<img width="870" height="437" alt="image" src="https://github.com/user-attachments/assets/2e999aeb-3051-459b-a3d2-2b23e5294254" />
