### PR TITLE
Add correct route on doc page to Cell Population Graph app

### DIFF
--- a/apps/humanatlas.io/src/assets/content/cell-population-graphs/data.yaml
+++ b/apps/humanatlas.io/src/assets/content/cell-population-graphs/data.yaml
@@ -17,7 +17,7 @@ content:
           (e.g., age, ethnicity, sex, or UV exposure).
       - component: Button
         label: Use app
-        href: https://hubmapconsortium.github.io/tissue-bar-graphs/
+        href: https://apps.humanatlas.io/cell-population-graphs
         type: cta
   - component: PageSection
     tagline: Example visualization


### PR DESCRIPTION
Currently, the Cell Populations Graph page links to the old app. I added the current app route.