### PR TITLE
Update app documentation link and typo in release notes

### DIFF
--- a/apps/humanatlas.io/src/assets/content/release-notes-page/v2.4.yaml
+++ b/apps/humanatlas.io/src/assets/content/release-notes-page/v2.4.yaml
@@ -200,7 +200,7 @@ content:
 
               * **Explore the app:** [Knowledge Graph](https://lod.humanatlas.io)
               * **New help & documentation content:**
-                * [App documentation](https://humanatlas.io/kg): Start here, then go to the developer documentation when you are ready to work with the data programmatically
+                * [App documentation](https://docs.humanatlas.io/apps/kg): Start here, then go to the developer documentation when you are ready to work with the data programmatically
                 * [Developer documentation](https://docs.humanatlas.io/dev/kg)
               * **Read publication:** Bueckle, Andreas, Bruce W. Herr II, Josef Hardi, Ellen M Quardokus, Mark A. Musen, and Katy Börner. 2025\. ["Construction, Deployment, and Usage of the Human Reference Atlas Knowledge Graph"](https://www.nature.com/articles/s41597-025-05183-6). *Nature Scientific Data* doi: 10.1038/s41597-025-05183-6.
 


### PR DESCRIPTION
Release notes fixes:
- Fixed KG app doc link: https://humanatlas.io/kg
- Fixed typo on same line