### PR TITLE
Amatria page: Add link to handout

### DIFF
--- a/apps/cns-website/public/assets/content/amatria/data.yaml
+++ b/apps/cns-website/public/assets/content/amatria/data.yaml
@@ -56,7 +56,7 @@ content:
             tagline: Dendrite
             content:
               - component: Markdown
-                data: Each _Amatria_ Dendrite has one light sensor (the eye) and actuators, such as lights and a strand of shape memory alloy, that makes the sculpture move. Software controls the sensor and actuators. Dendrite fields were built in the 2017 ISE Summer Camp.
+                data: Each _Amatria_ Dendrite has one light sensor (the eye) and actuators, such as lights and a strand of shape memory alloy, that makes the sculpture move. Software controls the sensor and actuators. Dendrite fields were built in the [2017 ISE Summer Camp](https://cns.iu.edu/assets/content/amatria/2017-iu-summer-camp-dendrite.pdf).
             actionsLeft:
               component: TextHyperlink
               text: View manual


### PR DESCRIPTION
Updated content to include a hyperlink for the 2017 ISE Summer Camp.