### PR TITLE
Update URL for Visible Human Course in menu and about page

### DIFF
--- a/apps/humanatlas.io/public/assets/content/about-page/data.yaml
+++ b/apps/humanatlas.io/public/assets/content/about-page/data.yaml
@@ -10,7 +10,7 @@ subtitle: |
   - Access high-quality linked open data HRA data programmatically to advance research or train machine learning algorithms in support of clinical applications.
   - Use open-source code and applications to compute and compare cell type populations and cell distance distributions for various cell types to characterize ageing and disease.
 
-  The [Visible Human Massive Open Online Course](https://expand.iu.edu/browse/sice/cns/courses/hubmap-visible-human-mooc/) (VHMOOC) describes the compilation and coverage of HRA data, demonstrates new single-cell analysis and mapping techniques, and introduces major features of the HRA Portal.
+  The [Visible Human Massive Open Online Course](https://expand.iu.edu/browse/sice/cns/courses/visible-human-mooc) (VHMOOC) describes the compilation and coverage of HRA data, demonstrates new single-cell analysis and mapping techniques, and introduces major features of the HRA Portal.
 
   New HRA releases are issued on June 15 and December 15 each year.
 content:

--- a/libs/design-system/navigation/header/src/lib/static-data/menus.json
+++ b/libs/design-system/navigation/header/src/lib/static-data/menus.json
@@ -199,7 +199,7 @@
             {
               "type": "item",
               "label": "Visible Human Course",
-              "url": "https://expand.iu.edu/browse/sice/cns/courses/hubmap-visible-human-mooc/",
+              "url": "https://expand.iu.edu/browse/sice/cns/courses/visible-human-mooc",
               "external": true
             },
             {


### PR DESCRIPTION
Update route to new: https://expand.iu.edu/browse/sice/cns/courses/visible-human-mooc