### PR TITLE
Improve Action Card typography and edit HRA content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository instructions
+
+- Do not install, remove, or upgrade dependencies unless the user explicitly asks for that dependency change.
+- Do not run dependency installation commands, including `npm install`, `npm ci`, `yarn install`, or `pnpm install`, without that explicit request.
+- If a task appears to require a dependency change, explain why and ask the user before modifying a package manifest or lockfile.

--- a/apps/docs.humanatlas.io/public/assets/content/visual-assets-page/data.yaml
+++ b/apps/docs.humanatlas.io/public/assets/content/visual-assets-page/data.yaml
@@ -200,7 +200,7 @@ content:
         data: |
           All HRA digital objects, such as 2D functional tissue unit illustrations and 3D models (3D functional tissue units, 3D reference objects, and landmarks), are available for download via the [HRA Knowledge Graph Explorer](https://apps.humanatlas.io/kg-explorer).
 
-          HRA visual assets may also be exported from National Institutes of Health websites, such as [NIH 3D](https://3d.nih.gov), and [NIH BioArt Source](https://bioart.nih.gov).
+          HRA visual assets may also be exported from National Institutes of Health websites, such as [NIH 3D](https://3d.nih.gov) and [NIH BioArt Source](https://bioart.nih.gov).
 
       - component: GridContainer
         content:

--- a/apps/docs.humanatlas.io/src/app/schemas/content-page/content-page.schema.json
+++ b/apps/docs.humanatlas.io/src/app/schemas/content-page/content-page.schema.json
@@ -185,6 +185,9 @@
         "variant": {
           "$ref": "#/$defs/ActionCardVariant"
         },
+        "eyebrow": {
+          "type": "string"
+        },
         "tagline": {
           "type": "string"
         },

--- a/apps/docs.humanatlas.io/src/app/schemas/landing-page/landing-page.schema.json
+++ b/apps/docs.humanatlas.io/src/app/schemas/landing-page/landing-page.schema.json
@@ -49,6 +49,9 @@
         "variant": {
           "$ref": "#/$defs/ActionCardVariant"
         },
+        "eyebrow": {
+          "type": "string"
+        },
         "tagline": {
           "type": "string"
         },

--- a/apps/humanatlas.io/public/assets/content/asctb-tables-page/data.yaml
+++ b/apps/humanatlas.io/public/assets/content/asctb-tables-page/data.yaml
@@ -45,7 +45,7 @@ content:
         across biological scales.
 
   - component: PageSection
-    tagline: ASCT+B tables by HRA release
+    tagline: 'Summary statistics: ASCT+B tables by HRA release'
     anchor: summary-statistics
     level: 2
     content:
@@ -300,7 +300,7 @@ content:
           Technically, [CCF Tools](https://github.com/hubmapconsortium/ccf-validation-tools) is a Python-based workflow that compares table content with [Ubergraph](https://github.com/INCATools/ubergraph), an integrated RDF triplestore with a SPARQL interface. Ubergraph brings together biomedical ontologies including [Uberon](https://obophenotype.github.io/uberon/about), which represents anatomical structures, and the [Cell Ontology](https://cell-ontology.github.io/), which defines biological cell types.
 
   - component: PageSection
-    tagline: Explore relationships in the ASCT+B Reporter
+    tagline: Visualize relationships with the ASCT+B Reporter
     anchor: app-visualize-asctb-tables
     level: 2
     content:

--- a/apps/humanatlas.io/public/assets/content/asctb-tables-page/data.yaml
+++ b/apps/humanatlas.io/public/assets/content/asctb-tables-page/data.yaml
@@ -1,6 +1,6 @@
 $schema: ../../../app/schemas/content-page/content-page.schema.json
 title: ASCT+B Tables
-subtitle: Human organ systems organized in nested levels from anatomical structures down to subcellular biomarkers.
+subtitle: Expert-curated reference data connecting human anatomy, cell types, and biomarkers across the Human Reference Atlas.
 icons: product:asctb-reporter
 action:
   label: Get data
@@ -13,26 +13,59 @@ content:
     content:
       component: Markdown
       data: |
-        Anatomical Structures, Cell Types, and Biomarkers (ASCT+B) tables aim to capture the nested part_of structure of
-        anatomical human body parts, the typology of cells, and the biomarkers used to identify cell types (e.g., gene, protein,
-        lipid or metabolic markers). The tables are authored and reviewed by an international team of anatomists, pathologists,
-        physicians, and other experts.
+        Anatomical Structures, Cell Types, and Biomarkers (ASCT+B) tables are expert-curated [digital objects](/overview-data) that describe the healthy human body at three connected scales:
+
+        - **Anatomical structures (AS):** The parts that make up an organ, organized from larger structures to smaller ones.
+        - **Cell types (CT):** The cells found within those anatomical structures.
+        - **Biomarkers (B):** The genes, proteins, lipids, metabolites, and proteoforms used to characterize those cell types.
+
+        Together, these connections create a structured map from the organ level to the cellular and molecular levels. Each table
+        focuses on an organ or organ system and aligns its terms with established biomedical ontologies. The tables are authored
+        and reviewed by an international team of anatomists, pathologists, physicians, and other domain experts.
+
   - component: PageSection
-    tagline: Summary statistics
+    tagline: How ASCT+B tables support the HRA
+    anchor: how-asctb-tables-support-the-hra
+    level: 2
+    content:
+      component: Markdown
+      data: |
+        ASCT+B tables turn expert knowledge about the human body into a shared, machine-readable reference. Consistent names,
+        identifiers, and relationships make it possible to connect and compare data produced by different researchers,
+        technologies, and studies.
+
+        Within the Human Reference Atlas, ASCT+B tables:
+
+        - provide core anatomical, cellular, and molecular relationships for the HRA Knowledge Graph
+        - support consistent annotation and integration across HRA digital objects and datasets
+        - connect experimental data to a common reference for exploration and analysis
+        - preserve changes through versioned releases that can be cited and reused
+
+        This shared foundation helps the HRA represent not only what structures and cells exist, but also how they are related
+        across biological scales.
+
+  - component: PageSection
+    tagline: ASCT+B tables by HRA release
     anchor: summary-statistics
-    level: 3
+    level: 2
     content:
       - component: Markdown
         data: |
-          The below table lists for each organ the number of anatomical structures (#AS), the number of cell types (#CT), the number of
-          biomarkers (#B), the number of part_of relationships between AS, the number of located_in links between CT and AS, and the number of
-          CT and B (i.e., which B characterize a CT). Biomarker abbreviations: genes (BG), proteins (BP), metabolites (BM), proteoforms (BF), and lipids (BL).
+          Choose an HRA release to see which organ tables are available, explore an individual table, or download its data.
+          The counts summarize each table's content and coverage:
+
+          - **#AS, #CT, and #B:** Anatomical structures, cell types, and biomarkers.
+          - **#AS-AS:** `part_of` relationships between anatomical structures.
+          - **#AS-CT:** `located_in` relationships connecting cell types to anatomical structures.
+          - **#CT-BM:** `characterizes` relationships connecting biomarkers to cell types.
+          - **#BG, #BP, #BM, #BF, and #BL:** Gene, protein, metabolite, proteoform, and lipid biomarkers.
+          - **NoLink, NoCT, and NoB:** Entries without an ontology link or without an expected cell type or biomarker connection.
       - component: VersionedDataTable
         styles:
           --hra-table-max-height: 35rem
         controllers:
           - id: VersionedTableParamSync
-        label: Release Version
+        label: Release version
         items:
           - label: 11th Release (v2.5)
             version: v2.5
@@ -243,40 +276,40 @@ content:
                 label: '#CT-BM'
                 type: numeric
   - component: PageSection
-    tagline: Standard operating procedures (SOPs)
+    tagline: Standard operating procedures for ASCT+B table creation
     anchor: sop
-    level: 3
-    content:
-      - component: Markdown
-        data: |
-          -  [SOP: Authoring Anatomical Structures, Cell Types, and Biomarkers (ASCT+B) Tables](https://doi.org/10.5281/zenodo.5746152)
-          -  [SOP: ASCT+B Table Communications](https://doi.org/10.5281/zenodo.5639622)
-  - component: PageSection
-    tagline: Use app to visualize ASCT+B tables
-    anchor: app-visualize-asctb-tables
     level: 2
     content:
       - component: Markdown
         data: |
-          The ASCT+B Reporter makes it possible to explore tables visually—per organ or across all organs—in support of table authoring and review.
-          It combines two different types of Angular visualizations: 1) A partonomy tree of anatomical structures, 2) bimodal networks that
-          link anatomical structures to cell types and cell types to biomarkers.<br><br>
-      - component: TextHyperlink
-        text: Use app
-        url: https://apps.humanatlas.io/asctb-reporter/
-        icon: arrow_right_alt
+          Domain experts use a shared template and documented review process to create consistent, interoperable ASCT+B tables.
+          These standard operating procedures (SOPs) define how tables are authored, structured, reviewed, and communicated:
+
+          -  [SOP: Authoring Anatomical Structures, Cell Types, and Biomarkers (ASCT+B) Tables](https://doi.org/10.5281/zenodo.5746152)
+          -  [SOP: ASCT+B Table Communications](https://doi.org/10.5281/zenodo.5639622)
 
   - component: PageSection
-    tagline: Ontology validation reports
+    tagline: How ASCT+B tables are validated
     anchor: ontology-validation-reports
     level: 2
     content:
       - component: Markdown
         data: |
-          ASCT+B table drafts are run through a Python script called CCF_Tools each week. The script reads them in, compares them against the
-          Resource Description Framework (RDF) triple store database called Ubergraph (Uberon and Cell Ontology), and outputs a validation report that
-          can be used to improve tables during creation or revision cycles.<br><br>
-      - component: TextHyperlink
-        text: View reports
-        url: https://hubmapconsortium.github.io/ccf-validation-tools/
-        icon: arrow_right_alt
+          Each week, CCF Tools checks draft ASCT+B tables to help authors catch issues early and keep table content consistent. The resulting validation reports highlight missing identifiers, inconsistent labels, and other potential problems that can be addressed during table authoring and revision. Validations are posted weekly at [ASCT+B Validation Reports](https://hubmapconsortium.github.io/ccf-validation-tools).
+
+          Technically, [CCF Tools](https://github.com/hubmapconsortium/ccf-validation-tools) is a Python-based workflow that compares table content with [Ubergraph](https://github.com/INCATools/ubergraph), an integrated RDF triplestore with a SPARQL interface. Ubergraph brings together biomedical ontologies including [Uberon](https://obophenotype.github.io/uberon/about), which represents anatomical structures, and the [Cell Ontology](https://cell-ontology.github.io/), which defines biological cell types.
+
+  - component: PageSection
+    tagline: Explore relationships in the ASCT+B Reporter
+    anchor: app-visualize-asctb-tables
+    level: 2
+    content:
+      - component: Markdown
+        data: |
+          The [ASCT+B Reporter app](https://apps.humanatlas.io/asctb-reporter) transforms rows of table data into an interactive tree view of biological relationships. Explore one organ or compare multiple organs using a partonomy tree of anatomical structures and network views that connect anatomical structures to cell types and cell types to biomarkers.
+
+          Use the app to understand an organ's organization, inspect supporting ontology information, compare data, and
+          help review ASCT+B tables.
+
+      - component: Image
+        src: assets/ui-images/annotated-ui-asctb-reporter.png

--- a/apps/humanatlas.io/public/assets/content/asctb-tables-page/data.yaml
+++ b/apps/humanatlas.io/public/assets/content/asctb-tables-page/data.yaml
@@ -1,6 +1,6 @@
 $schema: ../../../app/schemas/content-page/content-page.schema.json
 title: ASCT+B Tables
-subtitle: Expert-curated reference data connecting human anatomy, cell types, and biomarkers across the Human Reference Atlas.
+subtitle: Human organ systems organized in nested levels from anatomical structures down to subcellular biomarkers.
 icons: product:asctb-reporter
 action:
   label: Get data
@@ -13,59 +13,26 @@ content:
     content:
       component: Markdown
       data: |
-        Anatomical Structures, Cell Types, and Biomarkers (ASCT+B) tables are expert-curated [digital objects](/overview-data) that describe the healthy human body at three connected scales:
-
-        - **Anatomical structures (AS):** The parts that make up an organ, organized from larger structures to smaller ones.
-        - **Cell types (CT):** The cells found within those anatomical structures.
-        - **Biomarkers (B):** The genes, proteins, lipids, metabolites, and proteoforms used to characterize those cell types.
-
-        Together, these connections create a structured map from the organ level to the cellular and molecular levels. Each table
-        focuses on an organ or organ system and aligns its terms with established biomedical ontologies. The tables are authored
-        and reviewed by an international team of anatomists, pathologists, physicians, and other domain experts.
-
+        Anatomical Structures, Cell Types, and Biomarkers (ASCT+B) tables aim to capture the nested part_of structure of
+        anatomical human body parts, the typology of cells, and the biomarkers used to identify cell types (e.g., gene, protein,
+        lipid or metabolic markers). The tables are authored and reviewed by an international team of anatomists, pathologists,
+        physicians, and other experts.
   - component: PageSection
-    tagline: How ASCT+B tables support the HRA
-    anchor: how-asctb-tables-support-the-hra
-    level: 2
-    content:
-      component: Markdown
-      data: |
-        ASCT+B tables turn expert knowledge about the human body into a shared, machine-readable reference. Consistent names,
-        identifiers, and relationships make it possible to connect and compare data produced by different researchers,
-        technologies, and studies.
-
-        Within the Human Reference Atlas, ASCT+B tables:
-
-        - provide core anatomical, cellular, and molecular relationships for the HRA Knowledge Graph
-        - support consistent annotation and integration across HRA digital objects and datasets
-        - connect experimental data to a common reference for exploration and analysis
-        - preserve changes through versioned releases that can be cited and reused
-
-        This shared foundation helps the HRA represent not only what structures and cells exist, but also how they are related
-        across biological scales.
-
-  - component: PageSection
-    tagline: 'Summary statistics: ASCT+B tables by HRA release'
+    tagline: Summary statistics
     anchor: summary-statistics
-    level: 2
+    level: 3
     content:
       - component: Markdown
         data: |
-          Choose an HRA release to see which organ tables are available, explore an individual table, or download its data.
-          The counts summarize each table's content and coverage:
-
-          - **#AS, #CT, and #B:** Anatomical structures, cell types, and biomarkers.
-          - **#AS-AS:** `part_of` relationships between anatomical structures.
-          - **#AS-CT:** `located_in` relationships connecting cell types to anatomical structures.
-          - **#CT-BM:** `characterizes` relationships connecting biomarkers to cell types.
-          - **#BG, #BP, #BM, #BF, and #BL:** Gene, protein, metabolite, proteoform, and lipid biomarkers.
-          - **NoLink, NoCT, and NoB:** Entries without an ontology link or without an expected cell type or biomarker connection.
+          The below table lists for each organ the number of anatomical structures (#AS), the number of cell types (#CT), the number of
+          biomarkers (#B), the number of part_of relationships between AS, the number of located_in links between CT and AS, and the number of
+          CT and B (i.e., which B characterize a CT). Biomarker abbreviations: genes (BG), proteins (BP), metabolites (BM), proteoforms (BF), and lipids (BL).
       - component: VersionedDataTable
         styles:
           --hra-table-max-height: 35rem
         controllers:
           - id: VersionedTableParamSync
-        label: Release version
+        label: Release Version
         items:
           - label: 11th Release (v2.5)
             version: v2.5
@@ -276,40 +243,40 @@ content:
                 label: '#CT-BM'
                 type: numeric
   - component: PageSection
-    tagline: Standard operating procedures for ASCT+B table creation
+    tagline: Standard operating procedures (SOPs)
     anchor: sop
-    level: 2
+    level: 3
     content:
       - component: Markdown
         data: |
-          Domain experts use a shared template and documented review process to create consistent, interoperable ASCT+B tables.
-          These standard operating procedures (SOPs) define how tables are authored, structured, reviewed, and communicated:
-
           -  [SOP: Authoring Anatomical Structures, Cell Types, and Biomarkers (ASCT+B) Tables](https://doi.org/10.5281/zenodo.5746152)
           -  [SOP: ASCT+B Table Communications](https://doi.org/10.5281/zenodo.5639622)
-
   - component: PageSection
-    tagline: How ASCT+B tables are validated
-    anchor: ontology-validation-reports
-    level: 2
-    content:
-      - component: Markdown
-        data: |
-          Each week, CCF Tools checks draft ASCT+B tables to help authors catch issues early and keep table content consistent. The resulting validation reports highlight missing identifiers, inconsistent labels, and other potential problems that can be addressed during table authoring and revision. Validations are posted weekly at [ASCT+B Validation Reports](https://hubmapconsortium.github.io/ccf-validation-tools).
-
-          Technically, [CCF Tools](https://github.com/hubmapconsortium/ccf-validation-tools) is a Python-based workflow that compares table content with [Ubergraph](https://github.com/INCATools/ubergraph), an integrated RDF triplestore with a SPARQL interface. Ubergraph brings together biomedical ontologies including [Uberon](https://obophenotype.github.io/uberon/about), which represents anatomical structures, and the [Cell Ontology](https://cell-ontology.github.io/), which defines biological cell types.
-
-  - component: PageSection
-    tagline: Visualize relationships with the ASCT+B Reporter
+    tagline: Use app to visualize ASCT+B tables
     anchor: app-visualize-asctb-tables
     level: 2
     content:
       - component: Markdown
         data: |
-          The [ASCT+B Reporter app](https://apps.humanatlas.io/asctb-reporter) transforms rows of table data into an interactive tree view of biological relationships. Explore one organ or compare multiple organs using a partonomy tree of anatomical structures and network views that connect anatomical structures to cell types and cell types to biomarkers.
+          The ASCT+B Reporter makes it possible to explore tables visually—per organ or across all organs—in support of table authoring and review.
+          It combines two different types of Angular visualizations: 1) A partonomy tree of anatomical structures, 2) bimodal networks that
+          link anatomical structures to cell types and cell types to biomarkers.<br><br>
+      - component: TextHyperlink
+        text: Use app
+        url: https://apps.humanatlas.io/asctb-reporter/
+        icon: arrow_right_alt
 
-          Use the app to understand an organ's organization, inspect supporting ontology information, compare data, and
-          help review ASCT+B tables.
-
-      - component: Image
-        src: assets/ui-images/annotated-ui-asctb-reporter.png
+  - component: PageSection
+    tagline: Ontology validation reports
+    anchor: ontology-validation-reports
+    level: 2
+    content:
+      - component: Markdown
+        data: |
+          ASCT+B table drafts are run through a Python script called CCF_Tools each week. The script reads them in, compares them against the
+          Resource Description Framework (RDF) triple store database called Ubergraph (Uberon and Cell Ontology), and outputs a validation report that
+          can be used to improve tables during creation or revision cycles.<br><br>
+      - component: TextHyperlink
+        text: View reports
+        url: https://hubmapconsortium.github.io/ccf-validation-tools/
+        icon: arrow_right_alt

--- a/apps/humanatlas.io/public/assets/content/cell-population-graphs/data.yaml
+++ b/apps/humanatlas.io/public/assets/content/cell-population-graphs/data.yaml
@@ -1,5 +1,5 @@
 $schema: '../../../app/schemas/content-page/content-page.schema.json'
-title: Cell Population Graphs
+title: Cell Type Population Graphs
 subtitle: Compare cell type populations across datasets.
 icons: product:cell-population-graphs
 content:

--- a/apps/humanatlas.io/public/assets/content/cell-population-predictor-page/data.yaml
+++ b/apps/humanatlas.io/public/assets/content/cell-population-predictor-page/data.yaml
@@ -1,5 +1,5 @@
 $schema: '../../../app/schemas/content-page/content-page.schema.json'
-title: Cell Population Predictor
+title: Cell Type Population Predictor
 subtitle: Upload a 3D tissue extraction site to predict cell type populations for the site.
 icons: product:cell-population-predictor
 action:

--- a/apps/humanatlas.io/public/assets/content/data-page/data.yaml
+++ b/apps/humanatlas.io/public/assets/content/data-page/data.yaml
@@ -192,7 +192,7 @@ content:
               url: https://apps.humanatlas.io/kg-explorer
           - component: ActionCard
             variant: outlined
-            eyebrow: Documentation
+            eyebrow: Development documentation
             tagline: Knowledge Graph for developers
             content:
               - component: Markdown

--- a/apps/humanatlas.io/public/assets/content/data-page/data.yaml
+++ b/apps/humanatlas.io/public/assets/content/data-page/data.yaml
@@ -15,11 +15,29 @@ content:
     content:
       - component: Markdown
         data: |
-          Digital objects are unique data categories building the Human Reference Atlas. Digital objects are organized within the <a href="https://lod.humanatlas.io" target="_blank">Knowledge Graph database application</a>.
+          Digital objects build the data foundation of the Human Reference Atlas (HRA). This data is stored and organized in the HRA Knowledge Graph. Use the [Knowledge Graph Explorer](https://apps.humanatlas.io/kg-explorer) app to filter, query, and download HRA data.
+
           Digital objects may be connected to ontology terminology, such as <a href="https://www.ebi.ac.uk/ols4/ontologies/uberon" target="_blank">Uberon</a>, <a href="https://www.ebi.ac.uk/ols4/ontologies/cl" target="_blank">Cell Ontology (CL)</a>,
           and <a href="https://www.ebi.ac.uk/ols4/ontologies/pcl" target="_blank">Provisional Cell Ontology (PCL)</a>, via CSV files called crosswalk tables.
+
       - component: GridContainer
         content:
+          - component: ActionCard
+            variant: outlined-with-icons
+            tagline: 2D Functional Tissue Unit Illustrations
+            icons: product:ftu
+            content:
+              - component: Markdown
+                data: |
+                  Illustrations of the smallest tissue organization performing a unique physiologic function and is replicated multiple times in a human organ.
+            actionsLeft:
+              component: TextHyperlink
+              text: Learn more
+              url: /2d-ftu-illustrations?version=2.1&organ=Kidney
+            actionsRight:
+              component: TextHyperlink
+              text: Get data
+              url: https://purl.humanatlas.io/2d-ftu
           - component: ActionCard
             variant: outlined-with-icons
             tagline: 3D Reference Objects
@@ -34,7 +52,7 @@ content:
             actionsRight:
               component: TextHyperlink
               text: Get data
-              url: https://lod.humanatlas.io/ref-organ
+              url: https://purl.humanatlas.io/ref-organ
           - component: ActionCard
             variant: outlined-with-icons
             tagline: ASCT+B Tables
@@ -49,7 +67,7 @@ content:
             actionsRight:
               component: TextHyperlink
               text: Get data
-              url: https://lod.humanatlas.io/asct-b
+              url: https://purl.humanatlas.io/asct-b
           - component: ActionCard
             variant: outlined-with-icons
             tagline: Cell Type Annotation Crosswalks
@@ -64,24 +82,7 @@ content:
             actionsRight:
               component: TextHyperlink
               text: Get data
-              url: https://lod.humanatlas.io/ctann
-          - component: ActionCard
-            variant: outlined-with-icons
-            tagline: Functional Tissue Unit Illustrations
-            icons: product:ftu
-            content:
-              - component: Markdown
-                data: |
-                  Illustrations of the smallest tissue organization performing a unique physiologic function
-                  and is replicated multiple times in a human organ.
-            actionsLeft:
-              component: TextHyperlink
-              text: Learn more
-              url: /2d-ftu-illustrations?version=2.1&organ=Kidney
-            actionsRight:
-              component: TextHyperlink
-              text: Get data
-              url: https://lod.humanatlas.io/2d-ftu
+              url: https://purl.humanatlas.io/ctann
           - component: ActionCard
             variant: outlined-with-icons
             tagline: Millitomes
@@ -96,7 +97,7 @@ content:
             actionsRight:
               component: TextHyperlink
               text: Get data
-              url: https://lod.humanatlas.io/millitome
+              url: https://purl.humanatlas.io/millitome
           - component: ActionCard
             variant: outlined-with-icons
             tagline: Organ Mapping Antibody Panels
@@ -111,7 +112,121 @@ content:
             actionsRight:
               component: TextHyperlink
               text: Get data
-              url: https://lod.humanatlas.io/omap
+              url: https://purl.humanatlas.io/omap
+
+  - component: PageSection
+    tagline: HRA data access
+    anchor: data-access
+    level: 2
+    content:
+      - component: Markdown
+        data: |
+          Find applications, data packages, mirrors, APIs, and documentation for using HRA data.
+
+      - component: GridContainer
+        content:
+          - component: ActionCard
+            variant: outlined
+            eyebrow: App & documentation
+            tagline: API
+            content:
+              - component: Markdown
+                data: Query and interact with the Human Reference Atlas using Python, JavaScript, SPARQL, REST, and more.
+            actionsLeft:
+              component: TextHyperlink
+              text: Learn more
+              url: /api
+            actionsRight:
+              component: TextHyperlink
+              text: Use app
+              url: https://apps.humanatlas.io/api
+          - component: ActionCard
+            variant: outlined
+            eyebrow: Development documentation
+            tagline: API reference
+            content:
+              - component: Markdown
+                data: Review available endpoints, parameters, and response formats for the HRA API.
+            actionsLeft:
+              component: TextHyperlink
+              text: Learn more
+              url: https://docs.humanatlas.io/dev/api
+          - component: ActionCard
+            variant: outlined
+            eyebrow: Data mirror
+            tagline: Berlin data mirror
+            content:
+              - component: Markdown
+                data: Access HRA data through a mirror hosted in Berlin, Germany.
+            actionsLeft:
+              component: TextHyperlink
+              text: View mirror
+              icon: open_in_new
+              url: https://humanatlas.bihealth.org/mirror/
+          - component: ActionCard
+            variant: outlined
+            eyebrow: Data package
+            tagline: Download the HRA Knowledge Graph
+            content:
+              - component: Markdown
+                data: Export a versioned, citable snapshot of the HRA Knowledge Graph for local use or custom deployments.
+            actionsLeft:
+              component: TextHyperlink
+              text: Get data
+              icon: open_in_new
+              url: https://doi.org/10.5281/zenodo.15323983
+          - component: ActionCard
+            variant: outlined
+            eyebrow: App & documentation
+            tagline: Knowledge Graph Explorer
+            content:
+              - component: Markdown
+                data: Filter, query, and download Human Reference Atlas digital object data.
+            actionsLeft:
+              component: TextHyperlink
+              text: Learn more
+              url: https://docs.humanatlas.io/apps/kg
+            actionsRight:
+              component: TextHyperlink
+              text: Use app
+              url: https://apps.humanatlas.io/kg-explorer
+          - component: ActionCard
+            variant: outlined
+            eyebrow: Documentation
+            tagline: Knowledge Graph for developers
+            content:
+              - component: Markdown
+                data: Technical documentation for accessing, integrating, and working with HRA Knowledge Graph data.
+            actionsLeft:
+              component: TextHyperlink
+              text: Learn more
+              url: https://docs.humanatlas.io/apps/kg
+          - component: ActionCard
+            variant: outlined
+            eyebrow: Standard operating procedure
+            tagline: Set up a data mirror
+            content:
+              - component: Markdown
+                data: |
+                  Follow the standard operating procedure for hosting and maintaining an HRA data mirror.
+            actionsLeft:
+              component: TextHyperlink
+              text: Learn more
+              icon: open_in_new
+              url: https://doi.org/10.5281/zenodo.17873664
+          - component: ActionCard
+            variant: outlined
+            eyebrow: Data mirror
+            tagline: Shanghai data mirror
+            content:
+              - component: Markdown
+                data: Access HRA data through a mirror hosted in Shanghai, China.
+            actionsLeft:
+              component: TextHyperlink
+              text: View mirror
+              icon: open_in_new
+              url: https://msdc.fudan.edu.cn/humanatlas-mirror
+
   - component: PageSection
     tagline: Collaborator data portals
     anchor: collaborator-data-portals
@@ -120,6 +235,7 @@ content:
       - component: Markdown
         data: |
           Explore data repositories from collaborators who help build the evolving Human Reference Atlas.
+
       - component: GridContainer
         content:
           - component: ActionCard
@@ -129,6 +245,7 @@ content:
             actionsLeft:
               component: TextHyperlink
               text: Explore
+              icon: open_in_new
               url: https://portal.hubmapconsortium.org/
           - component: ActionCard
             variant: outlined
@@ -137,6 +254,7 @@ content:
             actionsLeft:
               component: TextHyperlink
               text: Explore
+              icon: open_in_new
               url: https://data.sennetconsortium.org/
           - component: ActionCard
             variant: outlined
@@ -145,6 +263,7 @@ content:
             actionsLeft:
               component: TextHyperlink
               text: Explore
+              icon: open_in_new
               url: https://www.kpmp.org/
           - component: ActionCard
             variant: outlined
@@ -153,6 +272,7 @@ content:
             actionsLeft:
               component: TextHyperlink
               text: Explore
+              icon: open_in_new
               url: https://www.gtexportal.org/home/
           - component: ActionCard
             variant: outlined
@@ -161,4 +281,5 @@ content:
             actionsLeft:
               component: TextHyperlink
               text: Explore
+              icon: open_in_new
               url: https://strandlab.net/GUDMAP/

--- a/apps/humanatlas.io/public/assets/content/data-page/data.yaml
+++ b/apps/humanatlas.io/public/assets/content/data-page/data.yaml
@@ -59,7 +59,7 @@ content:
             icons: product:asctb-reporter
             content:
               - component: Markdown
-                data: Human organ systems organized in nested levels from anatomical structures down to subcellular biomarkers.
+                data: Expert-curated reference data connecting human anatomy, cell types, and biomarkers across the Human Reference Atlas.
             actionsLeft:
               component: TextHyperlink
               text: Learn more

--- a/apps/humanatlas.io/src/app/schemas/content-page/content-page.schema.json
+++ b/apps/humanatlas.io/src/app/schemas/content-page/content-page.schema.json
@@ -192,6 +192,9 @@
         "variant": {
           "$ref": "#/$defs/ActionCardVariant"
         },
+        "eyebrow": {
+          "type": "string"
+        },
         "tagline": {
           "type": "string"
         },

--- a/libs/design-system/cards/action-card/src/lib/action-card.component.html
+++ b/libs/design-system/cards/action-card/src/lib/action-card.component.html
@@ -11,6 +11,9 @@
 }
 
 <div class="content">
+  @if (variant() === 'outlined' && eyebrow()) {
+    <div class="eyebrow">{{ eyebrow() }}</div>
+  }
   @if (variant() === 'elevated') {
     <div class="subtagline">{{ subtagline() }}</div>
   }

--- a/libs/design-system/cards/action-card/src/lib/action-card.component.scss
+++ b/libs/design-system/cards/action-card/src/lib/action-card.component.scss
@@ -104,10 +104,18 @@
 
   &.hra-action-card-variant-outlined {
     .content {
-      margin: 0.75rem 1rem;
+      margin: 1rem;
+
+      .eyebrow {
+        @include utils.use-font(body, small);
+        color: vars.$on-surface-variant;
+        font-weight: 500;
+        text-transform: uppercase;
+        margin-bottom: 0.75rem;
+      }
 
       .tagline {
-        margin-bottom: 0.25rem;
+        margin-bottom: 0.5rem;
       }
     }
   }

--- a/libs/design-system/cards/action-card/src/lib/action-card.component.spec.ts
+++ b/libs/design-system/cards/action-card/src/lib/action-card.component.spec.ts
@@ -14,6 +14,41 @@ describe('ActionCardComponent', () => {
     await expect(promise).resolves.toBeTruthy();
   });
 
+  it('should show the eyebrow for outlined cards when specified', async () => {
+    await render(ActionCardComponent, {
+      inputs: {
+        variant: 'outlined',
+        eyebrow: 'Digital object',
+        tagline: 'Title',
+      },
+    });
+
+    expect(screen.getByText('Digital object')).toHaveClass('eyebrow');
+  });
+
+  it('should hide the eyebrow when omitted', async () => {
+    await render(ActionCardComponent, {
+      inputs: {
+        variant: 'outlined',
+        tagline: 'Title',
+      },
+    });
+
+    expect(document.querySelector('.eyebrow')).not.toBeInTheDocument();
+  });
+
+  it('should hide the eyebrow for outlined-with-icons cards', async () => {
+    await render(ActionCardComponent, {
+      inputs: {
+        variant: 'outlined-with-icons',
+        eyebrow: 'Digital object',
+        tagline: 'Title',
+      },
+    });
+
+    expect(screen.queryByText('Digital object')).not.toBeInTheDocument();
+  });
+
   it('should set the correct alignment for the action', async () => {
     await render(
       `<hra-action-card variant="elevated" tagline="Title">

--- a/libs/design-system/cards/action-card/src/lib/action-card.component.stories.ts
+++ b/libs/design-system/cards/action-card/src/lib/action-card.component.stories.ts
@@ -36,7 +36,7 @@ type Story = StoryObj<ActionCardComponent & WithContent>;
 function render(variant: ActionCardVariant, actions: string): Story['render'] {
   return (args) => ({
     props: args,
-    template: `<hra-action-card variant="${variant}" [tagline]="tagline" [subtagline]="subtagline" [image]="image" [icons]="icons">
+    template: `<hra-action-card variant="${variant}" [eyebrow]="eyebrow" [tagline]="tagline" [subtagline]="subtagline" [image]="image" [icons]="icons">
       ${args.content}
       ${actions}
     </hra-action-card>`,
@@ -89,11 +89,31 @@ export const Flat: Story = {
 };
 
 export const Outlined: Story = {
+  args: {
+    eyebrow: 'Standard operating procedure',
+    tagline: 'Create an HRA data mirror',
+    content: 'Follow the standard operating procedure for hosting and maintaining an HRA data mirror.',
+  },
   render: render(
     'outlined',
     `<hra-action-card-action>
       <a hraHyperlink href="https://google.com">
-        Action
+        Learn more
+      </a>
+    </hra-action-card-action>`,
+  ),
+};
+
+export const OutlinedWithoutEyebrow: Story = {
+  args: {
+    tagline: 'Explore Human Reference Atlas data',
+    content: 'Find data, tools, and resources for using the Human Reference Atlas.',
+  },
+  render: render(
+    'outlined',
+    `<hra-action-card-action>
+      <a hraHyperlink href="https://google.com">
+        Explore data
       </a>
     </hra-action-card-action>`,
   ),

--- a/libs/design-system/cards/action-card/src/lib/action-card.component.ts
+++ b/libs/design-system/cards/action-card/src/lib/action-card.component.ts
@@ -34,6 +34,8 @@ export class ActionCardActionComponent {
 export class ActionCardComponent {
   /** Card layout variant */
   readonly variant = input.required<ActionCardVariant>();
+  /** Small label shown above the title for `outlined` cards */
+  readonly eyebrow = input<string>();
   /** Title */
   readonly tagline = input.required<string>();
   /** Smaller title show above the primary title for `elevated` cards */

--- a/libs/design-system/cards/action-card/src/lib/action-card.schema.spec.ts
+++ b/libs/design-system/cards/action-card/src/lib/action-card.schema.spec.ts
@@ -1,0 +1,24 @@
+import { ActionCardSchema } from './action-card.schema';
+
+describe('ActionCardSchema', () => {
+  it('should accept an outlined card with an eyebrow', () => {
+    const result = ActionCardSchema.safeParse({
+      component: 'ActionCard',
+      variant: 'outlined',
+      eyebrow: 'Digital object',
+      tagline: 'Title',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept an outlined card without an eyebrow', () => {
+    const result = ActionCardSchema.safeParse({
+      component: 'ActionCard',
+      variant: 'outlined',
+      tagline: 'Title',
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/libs/design-system/cards/action-card/src/lib/action-card.schema.ts
+++ b/libs/design-system/cards/action-card/src/lib/action-card.schema.ts
@@ -17,6 +17,8 @@ export type ActionCard = z.infer<typeof ActionCardSchema>;
 export const ActionCardSchema = ContentTemplateSchema.extend({
   component: z.literal('ActionCard'),
   variant: ActionCardVariantSchema,
+  /** Accepted for all variants, but only rendered by the `outlined` variant */
+  eyebrow: z.string().optional(),
   tagline: z.string(),
   subtagline: z.string().optional(),
   image: z.string().optional(),

--- a/libs/design-system/content-templates/markdown/src/lib/markdown.component.scss
+++ b/libs/design-system/content-templates/markdown/src/lib/markdown.component.scss
@@ -1,7 +1,21 @@
+@use '../../../../styles/utils';
+@use '../../../../styles/vars' as vars;
+
 :host {
   display: block;
 
   markdown ::ng-deep {
+    // Keep fenced code blocks on their existing presentation.
+    :not(pre) > code {
+      @include utils.use-font(code, medium);
+
+      background-color: vars.$surface-container-high;
+      border-radius: 0.25rem;
+      box-decoration-break: clone;
+      overflow-wrap: anywhere;
+      padding: 0.125rem 0.25rem;
+    }
+
     p {
       margin: 0.75rem 0;
       line-height: 1.6875rem;

--- a/libs/design-system/content-templates/markdown/src/lib/markdown.component.spec.ts
+++ b/libs/design-system/content-templates/markdown/src/lib/markdown.component.spec.ts
@@ -42,4 +42,36 @@ describe('MarkdownComponent', () => {
 
     expect(screen.getByRole('heading', { name: /test/i })).toBeInTheDocument();
   });
+
+  it.each([
+    ['markdown backticks', 'Use `part_of` relationships.'],
+    ['an HTML code element', 'Use <code>part_of</code> relationships.'],
+  ])('should render inline code authored with %s', async (_, data) => {
+    const { container } = await setup(data);
+
+    const code = container.querySelector('code');
+    expect(code).toHaveTextContent('part_of');
+    expect(code?.matches(':not(pre) > code')).toBe(true);
+  });
+
+  it('should keep fenced code blocks separate from inline code', async () => {
+    const { container } = await setup('```\nconst relationship = "part_of";\n```');
+
+    const code = container.querySelector('pre > code');
+    expect(code).toHaveTextContent('const relationship = "part_of";');
+    expect(code?.matches(':not(pre) > code')).toBe(false);
+  });
+
+  it('should render inline code inside a link', async () => {
+    const { container } = await setup('[`part_of`](https://example.com)');
+
+    expect(container.querySelector('a > code')).toHaveTextContent('part_of');
+  });
+
+  it('should preserve long inline code values that may wrap', async () => {
+    const value = 'a-very-long-machine-readable-relationship-identifier-that-may-wrap';
+    const { container } = await setup(`Use \`${value}\` in the query.`);
+
+    expect(container.querySelector('code')).toHaveTextContent(value);
+  });
 });

--- a/libs/design-system/src/lib/material-demos/input.component.stories.ts
+++ b/libs/design-system/src/lib/material-demos/input.component.stories.ts
@@ -95,6 +95,38 @@ export const RequiredInputWithValidation: Story = {
   }),
 };
 
+export const WithHelperText: Story = {
+  render: () => ({
+    template: `
+      <mat-form-field appearance="outline">
+        <mat-label>Email address</mat-label>
+        <input type="email" matInput placeholder="name@example.com">
+        <mat-hint>We will only use this to contact you.</mat-hint>
+      </mat-form-field>
+    `,
+  }),
+};
+
+export const WithErrorText: Story = {
+  render: () => {
+    const emailFormControl = new FormControl('', Validators.required);
+    emailFormControl.markAsTouched();
+
+    return {
+      props: {
+        emailFormControl,
+      },
+      template: `
+        <mat-form-field appearance="outline">
+          <mat-label>Email address</mat-label>
+          <input type="email" matInput [formControl]="emailFormControl" placeholder="name@example.com">
+          <mat-error>Email address is required.</mat-error>
+        </mat-form-field>
+      `,
+    };
+  },
+};
+
 export const InputWithClearButton: Story = {
   render: () => ({
     props: {

--- a/libs/design-system/src/lib/material-demos/normal-list/list-item.stories.ts
+++ b/libs/design-system/src/lib/material-demos/normal-list/list-item.stories.ts
@@ -65,3 +65,17 @@ export const WithSupportingTextTertiary: StoryObj = {
 `,
   }),
 };
+
+export const WithTrailingSupportingText: StoryObj = {
+  name: 'With Trailing Supporting Text',
+  render: () => ({
+    template: `
+    <mat-list>
+      <mat-list-item>
+        <span matListItemTitle>Published datasets</span>
+        <span matListItemMeta>12 items</span>
+      </mat-list-item>
+    </mat-list>
+`,
+  }),
+};

--- a/libs/design-system/styles/_typography.scss
+++ b/libs/design-system/styles/_typography.scss
@@ -91,7 +91,12 @@ $overrides: (
 
   body-large-tracking: 0rem,
   body-medium-tracking: 0rem,
-  body-small-tracking: 0rem,
+  body-small: 400 0.75rem / 1.125rem $_plain,
+  body-small-font: $_plain,
+  body-small-line-height: 1.125rem,
+  body-small-size: 0.75rem,
+  body-small-tracking: 0.025rem,
+  body-small-weight: 400,
 );
 
 @mixin custom-variants() {

--- a/libs/design-system/tooltips/plain-tooltip/src/plain-tooltip.stories.ts
+++ b/libs/design-system/tooltips/plain-tooltip/src/plain-tooltip.stories.ts
@@ -1,9 +1,10 @@
 import { moduleMetadata, type Meta, type StoryObj } from '@storybook/angular';
 import { PlainTooltipDirective } from './plain-tooltip.directive';
 import { MatButtonModule } from '@angular/material/button';
+import { userEvent, within } from 'storybook/test';
 
 const meta: Meta = {
-  title: 'PlainTooltip',
+  title: 'Design System/Tooltip/Plain Tooltip',
   args: {
     size: 'medium',
   },
@@ -26,10 +27,21 @@ export const Medium: Story = {
   render: (args) => ({
     props: args,
     template: `
-      <button mat-flat-button hraPlainTooltip="This is a Plain Tooltip of ${args['size']} variant"
+      <button mat-flat-button hraPlainTooltip="Helpful context for this action"
       hraPlainTooltipSize="${args['size']}">
-        Try Me!
+        Hover for details
       </button>
     `,
   }),
+  play: async ({ canvasElement }) => {
+    await userEvent.hover(within(canvasElement).getByRole('button'));
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: 'small',
+  },
+  render: Medium.render,
+  play: Medium.play,
 };


### PR DESCRIPTION
## Summary

This update improves Action Card hierarchy and typography, expands Human Reference Atlas content, improves inline code readability, and adds focused tests and Storybook review states.

## Visual tweaks

### Added optional eyebrow text to the outlined Action Card variant

- Eyebrow text is hidden when omitted from YAML
- Eyebrow text is not rendered by the `outlined-with-icons` variant
- Updated the Action Card schema and generated content schemas
- Added focused component and schema tests for cards with and without eyebrow text

### Updated outlined Action Card styling

- Increased the content inset to 16px
- Set eyebrow-to-tagline spacing to 12px
- Set tagline-to-description spacing to 8px
- Styled eyebrow text in uppercase using the `body-small` token
- Applied a medium font weight and the existing `on-surface-variant` color

### Updated the global `body-small` typography token to match the current Figma specification

- Font family: Nunito Sans
- Font size: 12px
- Line height: 18px
- Font weight: 400
- Letter spacing: 0.4px

### Added or refined Storybook review states for typography-sensitive components

- Outlined Action Card with eyebrow
- Outlined Action Card without eyebrow
- Small and medium plain tooltips
- Form-field helper text
- Form-field error text
- List trailing supporting text

### Improved inline code styling in Markdown content

- Added distinct typography, background color, padding, and rounded corners for inline code
- Allowed long machine-readable identifiers to wrap without overflowing
- Preserved the existing presentation of fenced code blocks
- Added tests for Markdown backticks, HTML code elements, linked inline code, long values, and fenced code blocks

## Content design

### humanatlas.io/overview-data

- Rewrote the introduction to clarify how digital objects support the Human Reference Atlas
- Added and reorganized digital-object and data-access cards
- Added eyebrow labels to outlined data-access cards
- Updated descriptions, links, icons, and external-link indicators
- Reorganized the 2D Functional Tissue Unit Illustrations digital-object card
- Added cards for the API, API reference, data mirrors, Knowledge Graph resources, downloadable data, and related documentation
- Replaced applicable Knowledge Graph URLs with persistent `purl.humanatlas.io` links
- Added external-link indicators to collaborator data-portal links

### docs.humanatlas.io/visual-assets

- Corrected punctuation on the visual-assets documentation page

### Page label updates

- Renamed “Cell Population Graphs” to “Cell Type Population Graphs”
- Renamed “Cell Population Predictor” to “Cell Type Population Predictor”


## Repository safeguards

### Added dependency-management guidance for coding agents

- Documented that dependencies must not be installed, removed, or upgraded without an explicit request
- Documented that package manifests and lockfiles must not be changed without prior approval